### PR TITLE
[Release Candidate] Version 1.2.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "AutoRename",
     "short_name": "AutoRename",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "AutoRename can automatically rename downloaded images from the internet.",
     "default_locale": "en",
     "manifest_version": 2,


### PR DESCRIPTION
- Fixed issue where saving an image on the Twitter Redesign will only download the small or medium image size. See issue #1 
- New context menu item to view the original image in a new tab.
- Bug fixes